### PR TITLE
Support opening files in-place

### DIFF
--- a/Sources/FilePicker/FilePicker.swift
+++ b/Sources/FilePicker/FilePicker.swift
@@ -34,12 +34,14 @@ public struct FilePicker<LabelView: View>: View {
     
     public let types: [UTType]
     public let allowMultiple: Bool
+    public let asCopy: Bool
     public let pickedCompletionHandler: PickedURLsCompletionHandler
     public let labelViewContent: LabelViewContent
     
-    public init(types: [UTType], allowMultiple: Bool, onPicked completionHandler: @escaping PickedURLsCompletionHandler, @ViewBuilder label labelViewContent: @escaping LabelViewContent) {
+    public init(types: [UTType], allowMultiple: Bool, asCopy: Bool = true, onPicked completionHandler: @escaping PickedURLsCompletionHandler, @ViewBuilder label labelViewContent: @escaping LabelViewContent) {
         self.types = types
         self.allowMultiple = allowMultiple
+        self.asCopy = asCopy
         self.pickedCompletionHandler = completionHandler
         self.labelViewContent = labelViewContent
     }
@@ -61,7 +63,7 @@ public struct FilePicker<LabelView: View>: View {
         )
         .disabled(isPresented)
         .sheet(isPresented: $isPresented) {
-            FilePickerUIRepresentable(types: types, allowMultiple: allowMultiple, onPicked: pickedCompletionHandler)
+            FilePickerUIRepresentable(types: types, allowMultiple: allowMultiple, asCopy: asCopy, onPicked: pickedCompletionHandler)
         }
     }
     

--- a/Sources/FilePicker/FilePicker.swift
+++ b/Sources/FilePicker/FilePicker.swift
@@ -46,8 +46,8 @@ public struct FilePicker<LabelView: View>: View {
         self.labelViewContent = labelViewContent
     }
 
-    public init(types: [UTType], allowMultiple: Bool, title: String, onPicked completionHandler: @escaping PickedURLsCompletionHandler) where LabelView == Text {
-        self.init(types: types, allowMultiple: allowMultiple, onPicked: completionHandler) { Text(title) }
+    public init(types: [UTType], allowMultiple: Bool, title: String, asCopy: Bool = true, onPicked completionHandler: @escaping PickedURLsCompletionHandler) where LabelView == Text {
+        self.init(types: types, allowMultiple: allowMultiple, asCopy: asCopy, onPicked: completionHandler) { Text(title) }
     }
     
     #if os(iOS)

--- a/Sources/FilePicker/FilePickerUIRepresentable.swift
+++ b/Sources/FilePicker/FilePickerUIRepresentable.swift
@@ -35,11 +35,13 @@ public struct FilePickerUIRepresentable: UIViewControllerRepresentable {
     
     public let types: [UTType]
     public let allowMultiple: Bool
+    public let asCopy: Bool
     public let pickedCompletionHandler: PickedURLsCompletionHandler
     
-    public init(types: [UTType], allowMultiple: Bool, onPicked completionHandler: @escaping PickedURLsCompletionHandler) {
+    public init(types: [UTType], allowMultiple: Bool, asCopy: Bool, onPicked completionHandler: @escaping PickedURLsCompletionHandler) {
         self.types = types
         self.allowMultiple = allowMultiple
+        self.asCopy = asCopy
         self.pickedCompletionHandler = completionHandler
     }
     
@@ -48,7 +50,7 @@ public struct FilePickerUIRepresentable: UIViewControllerRepresentable {
     }
     
     public func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
-        let picker = UIDocumentPickerViewController(forOpeningContentTypes: types, asCopy: true)
+        let picker = UIDocumentPickerViewController(forOpeningContentTypes: types, asCopy: asCopy)
         picker.delegate = context.coordinator
         picker.allowsMultipleSelection = allowMultiple
         return picker


### PR DESCRIPTION
This change provides a mechanism to pass the `asCopy` parameter to the underlying `UIDocumentPickerViewController` to allow opening files in-place, required for opening folders (`UTType.folder`).